### PR TITLE
Add inputs `no_cache`, and `package_files_only`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,34 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.dhallVersion }}
+
 inputs:
   dhallVersion:
-    description: 'Version of dhall-haskell to use (see: https://github.com/dhall-lang/dhall-haskell)'
     required: false
     default: '1.36.0'
+    description: |
+      Version of dhall-haskell to use.
+
+      Should be a tag from https://github.com/dhall-lang/dhall-haskell.
+
+  typecheck_no_cache:
+    required: false
+    default: false
+    description: |
+      Whether to pass `--no-cache` when typechecking.
+
+      Having this set to `false` (meaning: caching enabled) can greatly speed
+      up checking as the number of files to check increases. However, doing so
+      can also lead to some unpredictability, as caching in general can be
+      known to do.
+
+  typecheck_package_files_only:
+    required: false
+    default: false
+    description: |
+      Whether to only typecheck `package.dhall` files (as opposed to `*.dhall`.
+
+      The thought here is that checking `package.dhall` is likely to
+      transitively check all other `*.dhall`, so it should be sufficient while
+      avoiding lots of duplicated work. However, this is certainly not always
+      the case, so consider that when setting this input to `true`.

--- a/bin/_typecheck
+++ b/bin/_typecheck
@@ -2,14 +2,29 @@
 
 set -euo pipefail
 
+echo "Inputs:"
+env | grep -e '^INPUT_' || true
+echo "---"
+
 temp_file="$(mktemp)"
 
 collect_errors() {
+  if [ "${INPUT_TYPECHECK_PACKAGE_FILES_ONLY:-false}" = 'true' ]; then
+    local -r find_name='package.dhall'
+  else
+    local -r find_name='*.dhall'
+  fi
+
+  if [ "${INPUT_TYPECHECK_NO_CACHE:-true}" = 'true' ]; then
+    local -r no_cache_flag='--no-cache'
+  fi
+
+  echo "Typechecking, find_name: ${find_name}, no_cache_flag: ${no_cache_flag:-}"
   echo
-  find . -type f -name '*.dhall' | sort -u | while read -r fpath; do
+  find . -type f -name "${find_name}" | sort -u | while read -r fpath; do
     set +e
-    echo "Checking ${fpath} ..."
-    dhall --no-cache <<< "${fpath}" > /dev/null
+    echo "Typechecking ${fpath} ..."
+    dhall ${no_cache_flag:-} <<< "${fpath}" > /dev/null
     set -e
   done
 }

--- a/inputs.dhall
+++ b/inputs.dhall
@@ -3,11 +3,24 @@ let Prelude =
 
 let JSON = Prelude.JSON
 
-let type = { dhallVersion : Text }
+let type =
+      { dhallVersion : Text
+      , typecheck_no_cache : Bool
+      , typecheck_package_files_only : Bool
+      }
 
 in  { Type = type
-    , default.dhallVersion = "1.36.0"
+    , default =
+      { dhallVersion = "1.36.0"
+      , typecheck_no_cache = False
+      , typecheck_package_files_only = False
+      }
     , toJSON =
         λ(inputs : type) →
-          toMap { dhallVersion = JSON.string inputs.dhallVersion }
+          toMap
+            { dhallVersion = JSON.string inputs.dhallVersion
+            , typecheck_no_cache = JSON.bool inputs.typecheck_no_cache
+            , typecheck_package_files_only =
+                JSON.bool inputs.typecheck_package_files_only
+            }
     }


### PR DESCRIPTION
More detailed description can be obtained from action.yml, copy pasted here for convenience:

```yaml
  typecheck_no_cache:
    required: false
    default: false
    description: |
      Whether to pass `--no-cache` when typechecking.

      Having this set to `false` (meaning: caching enabled) can greatly speed
      up checking as the number of files to check increases. However, doing so
      can also lead to some unpredictability, as caching in general can be
      known to do.

  typecheck_package_files_only:
    required: false
    default: false
    description: |
      Whether to only typecheck `package.dhall` files (as opposed to `*.dhall`.

      The thought here is that checking `package.dhall` is likely to
      transitively check all other `*.dhall`, so it should be sufficient while
      avoiding lots of duplicated work. However, this is certainly not always
      the case, so consider that when setting this input to `true`.
```