### PR TITLE
Use absolute path to lib.sh

### DIFF
--- a/bin/_freeze
+++ b/bin/_freeze
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1091
-source lib.sh
+source /lib.sh # Sorta breaks ability to run this outside the container, but 🤷
 
 _check_version
 

--- a/bin/_lint
+++ b/bin/_lint
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1091
-source lib.sh
+source /lib.sh # Sorta breaks ability to run this outside the container, but 🤷
 
 _check_version
 


### PR DESCRIPTION
It's a bit unfortunate that it means you can't just run locally to test, but that's not the biggest problem in the world right in this moment.