### PR TITLE
Add input: `errorOnFreezeDiff`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,18 @@ runs:
 inputs:
   dhallVersion:
     required: false
-    default: '1.39.0'
+    default: '1.40.2'
     description: |
       Version of dhall-haskell to use.
 
       Should be a tag from https://github.com/dhall-lang/dhall-haskell.
+
+  errorOnFreezeDiff:
+    required: false
+    default: false
+    description: |
+      Whether a diff resulting from `dhall freeze` should be treated as an
+      error.
 
   typecheck_no_cache:
     required: false

--- a/bin/_freeze
+++ b/bin/_freeze
@@ -9,4 +9,17 @@ _check_version
 
 find . -type f -name '*.dhall' | sort -u | xargs -t dhall freeze
 
-git diff --color=always --exit-code
+
+error_on_freeze_diff="${INPUT_ERRORONFREEZEDIFF:-false}"
+
+echo "error_on_freeze_diff=${error_on_freeze_diff}"
+
+if [ "${error_on_freeze_diff}" = 'true' ]; then
+  echo git diff --color=always --exit-code
+       git diff --color=always --exit-code
+else
+  echo git diff --color=always
+       git diff --color=always
+fi
+
+git checkout -- .

--- a/bin/_lint
+++ b/bin/_lint
@@ -10,3 +10,5 @@ _check_version
 find . -type f -name '*.dhall' | sort -u | xargs -t dhall lint
 
 git diff --color=always --exit-code
+
+git checkout -- .

--- a/inputs.dhall
+++ b/inputs.dhall
@@ -4,13 +4,15 @@ let JSON = Prelude.JSON
 
 let type =
       { dhallVersion : Text
+      , errorOnFreezeDiff : Bool
       , typecheck_no_cache : Bool
       , typecheck_package_files_only : Bool
       }
 
 in  { Type = type
     , default =
-      { dhallVersion = "1.39.0"
+      { dhallVersion = "1.40.2"
+      , errorOnFreezeDiff = False
       , typecheck_no_cache = False
       , typecheck_package_files_only = False
       }
@@ -18,6 +20,7 @@ in  { Type = type
         λ(inputs : type) →
           toMap
             { dhallVersion = JSON.string inputs.dhallVersion
+            , errorOnFreezeDiff = JSON.bool inputs.errorOnFreezeDiff
             , typecheck_no_cache = JSON.bool inputs.typecheck_no_cache
             , typecheck_package_files_only =
                 JSON.bool inputs.typecheck_package_files_only


### PR DESCRIPTION
This controls whether or not a job errors when freezing dhall files ends up resulting in a diff.